### PR TITLE
Allow user output option in phpspec.yml to override defaults.

### DIFF
--- a/src/PhpSpec/Extension/Listener/CodeCoverageListener.php
+++ b/src/PhpSpec/Extension/Listener/CodeCoverageListener.php
@@ -66,7 +66,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
 
     public function setOptions(array $options)
     {
-        $this->options = array_merge($this->options, $options);
+        $this->options = $options + $this->options;
     }
 
     /**


### PR DESCRIPTION
I wanted to put my coverage report into `coverage/php`, but the option didn't get set. 

here is my phpspec.yml:

> extensions:
>     - PhpSpec\Extension\CodeCoverageExtension
> code_coverage:
>     output: coverage/php

basically in setOptions, $this->options & $options were the wrong way around, but rather than swap them I used array_merge.
