### PR TITLE
Made format of generated report configurable

### DIFF
--- a/src/PhpSpec/Extension/CodeCoverageExtension.php
+++ b/src/PhpSpec/Extension/CodeCoverageExtension.php
@@ -24,8 +24,20 @@ class CodeCoverageExtension implements \PhpSpec\Extension\ExtensionInterface
             return new \PHP_CodeCoverage(null, $container->get('code_coverage.filter'));
         });
 
-        $container->setShared('code_coverage.report', function () {
-            return new \PHP_CodeCoverage_Report_HTML;
+        $container->setShared('code_coverage.report', function ($container) {
+            $options = $container->getParam('code_coverage');
+
+            switch ($options['format']) {
+                case 'clover':
+                    return new \PHP_CodeCoverage_Report_Clover();
+                case 'php':
+                    return new \PHP_CodeCoverage_Report_PHP();
+                case 'text':
+                    return new \PHP_CodeCoverage_Report_Text(new \PHPUnit_Util_Printer());
+                case 'html':
+                default:
+                    return new \PHP_CodeCoverage_Report_HTML();
+            }
         });
 
         $container->setShared('event_dispatcher.listeners.code_coverage', function ($container) {

--- a/src/PhpSpec/Extension/Listener/CodeCoverageListener.php
+++ b/src/PhpSpec/Extension/Listener/CodeCoverageListener.php
@@ -13,7 +13,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
     private $io;
     private $options;
 
-    public function __construct(\PHP_CodeCoverage $coverage, \PHP_CodeCoverage_Report_HTML $report)
+    public function __construct(\PHP_CodeCoverage $coverage, $report)
     {
         $this->coverage = $coverage;
         $this->report   = $report;
@@ -21,6 +21,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
             'whitelist' => array('src', 'lib'),
             'blacklist' => array('vendor', 'spec'),
             'output'    => 'coverage',
+            'format'    => 'html',
         );
     }
 
@@ -53,7 +54,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
     {
         if ($this->io) {
             $this->io->writeln('');
-            $this->io->writeln('Generating code coverage report in HTML format ...');
+            $this->io->writeln(sprintf('Generating code coverage report in %s format ...', $this->options['format']));
         }
 
         $this->report->process($this->coverage, $this->options['output']);


### PR DESCRIPTION
Hi,

Because I needed the coverage as xml, I've added the option to change the output format from your phpspec.yml file:

``` yaml
code_coverage:
  format: clover
```

It supports clover, html, text and php.
