### PR TITLE
downgrade php requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
 
     "require" : {
-        "php"                       : ">=5.3.4",
+        "php"                       : ">=5.3.3",
         "phpspec/phpspec"           : "dev-master",
         "phpunit/php-code-coverage" : "~1.2"
     },


### PR DESCRIPTION
According to http://www.php.net/downloads.php 5.3.4 is not an official release. Could we downgrade requirement php in composer.json from 5.3.4 to 5.3.3 as it breaks composer update every time our developers try to update the project.

Cheers
