### PR TITLE
Use PHPSpec branch alias instead of dev-master in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 
     "require" : {
         "php"                       : ">=5.3.3",
-        "phpspec/phpspec"           : "dev-master",
+        "phpspec/phpspec"           : "2.0.*@dev",
         "phpunit/php-code-coverage" : "~1.2"
     },
 


### PR DESCRIPTION
When I tried to run `composer install` in my project I got the error:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - phpspec/phpspec dev-master requires phpspec/prophecy ~1.0.5@dev -> no matching package found.
    - henrikbjorn/phpspec-code-coverage 1.0.x-dev requires phpspec/phpspec dev-master -> satisfiable by phpspec/phpspec[dev-master].
    - Installation request for henrikbjorn/phpspec-code-coverage 1.0.*@dev -> satisfiable by henrikbjorn/phpspec-code-coverage[1.0.x-dev].
```

This project `composer.json` listed _PHPSpec_ in `dev-master`, which has a branch alias `2.0.*-dev`, and _PHPSpec_ depends on _Prophecy_ using other branch alias (`1.5.*-dev`).

Seems that composer was not fetching the _Prophecy_ branch alias when we don't use the _PHPSpec_ branch alias.

To reproduce this issue, just remove your vendor folder and install this extension without this pull request.

This pull request fix it by changing _PHPSpec_ dependency from `dev-master` to its alias `2.0.*@dev`
