### PR TITLE
Adding verbose option

### DIFF
--- a/src/PhpSpec/Extension/Listener/CodeCoverageListener.php
+++ b/src/PhpSpec/Extension/Listener/CodeCoverageListener.php
@@ -22,6 +22,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
             'blacklist' => array('vendor', 'spec'),
             'output'    => 'coverage',
             'format'    => 'html',
+            'verbose'   => 'true'
         );
     }
 
@@ -52,7 +53,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
 
     public function afterSuite(SuiteEvent $event)
     {
-        if ($this->io) {
+        if ($this->io && $this->options['verbose'] == 'true') {
             $this->io->writeln('');
             $this->io->writeln(sprintf('Generating code coverage report in %s format ...', $this->options['format']));
         }


### PR DESCRIPTION
I use phpspec to generate 2 reports. Test suite and coverage. Test suite report is flushed on stdio and coverage go to file. But at the end of test suite report a have "Generating code coverage report in %s format ...". This configuration option will prevent that.
