### PR TITLE
update php-code-coverage to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require" : {
         "php"                       : ">=5.3.3",
         "phpspec/phpspec"           : "2.0.*@dev",
-        "phpunit/php-code-coverage" : "~1.2"
+        "phpunit/php-code-coverage" : "~2.0"
     },
 
     "extra" : {


### PR DESCRIPTION
It seems that something was off with the version of php-code-coverage I had at the time of my previous contribution. One of the changes I made then are causing errors now with a clean checkout when text format is used.

It would be possible to fix that in the code, but it seems better to just update to a more recent version of php-code-coverage, where both text and html formats work as expected.
