### PR TITLE
Fixed output html by default

### DIFF
--- a/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
+++ b/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
@@ -74,4 +74,30 @@ class CodeCoverageListenerSpec extends ObjectBehavior
 
         $this->afterSuite($event);
     }
+
+    function it_should_output_html_report(
+        \PHP_CodeCoverage $coverage,
+        \PHP_CodeCoverage_Report_HTML $html,
+        SuiteEvent $event,
+        IO $io
+    ) {
+        $reports = array(
+            'html' => $html
+        );
+
+        $this->beConstructedWith($coverage, $reports);
+        $this->setOptions(array(
+            'format' => 'html',
+            'output' => array('html' => 'coverage'),
+        ));
+
+        $io->isVerbose()->willReturn(false);
+        $this->setIO($io);
+
+        $io->writeln('Generating code coverage report in html format ...')->shouldBeCalled();
+
+        $html->process($coverage, 'coverage')->willReturn('report');
+
+        $this->afterSuite($event);
+    }
 }

--- a/src/PhpSpec/Extension/Listener/CodeCoverageListener.php
+++ b/src/PhpSpec/Extension/Listener/CodeCoverageListener.php
@@ -22,7 +22,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
             'blacklist' => array('vendor', 'spec'),
             'whitelist_files' => array(),
             'blacklist_files' => array(),
-            'output'    => 'coverage',
+            'output'    => array('html' => 'coverage'),
             'format'    => array('html'),
         );
     }


### PR DESCRIPTION
With the last commit, the coverage doesn't work by default. You have to define the output.
