### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Add it to your `composer.json` file to install with [Composer](http://getcompose
 ``` json
 {
     "require" : {
-        "henrikbjorn/phpspec-code-coverage" : "1.0@dev"
+        "henrikbjorn/phpspec-code-coverage": "~0.2"
     }
 }
 ```


### PR DESCRIPTION
If you don't put that extra star there you will get the following error on `composer update`:

```
Your requirements could not be resolved to an installable set of packages.
```
