### PR TITLE
Do not produce output if the PhpSpec output format is junit or html

### DIFF
--- a/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
+++ b/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
@@ -100,4 +100,30 @@ class CodeCoverageListenerSpec extends ObjectBehavior
 
         $this->afterSuite($event);
     }
+
+    function it_should_not_generate_output_for_junit_phpspec_output(
+        \PHP_CodeCoverage $coverage,
+        \PHP_CodeCoverage_Report_HTML $html,
+        SuiteEvent $event,
+        IO $io
+    ) {
+        $reports = array(
+            'html' => $html
+        );
+
+        $this->beConstructedWith($coverage, $reports, 'junit');
+        $this->setOptions(array(
+            'format' => 'html',
+            'output' => array('html' => 'coverage'),
+        ));
+
+        $io->isVerbose()->willReturn(false);
+        $this->setIO($io);
+
+        $io->writeln(Argument::any())->shouldNotBeCalled();
+
+        $html->process($coverage, 'coverage')->willReturn('report');
+
+        $this->afterSuite($event);
+    }
 }

--- a/src/PhpSpec/Extension/CodeCoverageExtension.php
+++ b/src/PhpSpec/Extension/CodeCoverageExtension.php
@@ -92,7 +92,8 @@ class CodeCoverageExtension implements \PhpSpec\Extension\ExtensionInterface
         $container->setShared('event_dispatcher.listeners.code_coverage', function ($container) {
             $listener = new CodeCoverageListener(
                 $container->get('code_coverage'),
-                $container->get('code_coverage.reports')
+                $container->get('code_coverage.reports'),
+                $container->getParam('formatter.name')
             );
             $listener->setIO($container->get('console.io'));
             $listener->setOptions($container->getParam('code_coverage', array()));

--- a/src/PhpSpec/Extension/Listener/CodeCoverageListener.php
+++ b/src/PhpSpec/Extension/Listener/CodeCoverageListener.php
@@ -10,13 +10,15 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
 {
     private $coverage;
     private $reports;
+    private $format;
     private $io;
     private $options;
 
-    public function __construct(\PHP_CodeCoverage $coverage, array $reports)
+    public function __construct(\PHP_CodeCoverage $coverage, array $reports, $format = null)
     {
         $this->coverage = $coverage;
         $this->reports  = $reports;
+        $this->format   = $format;
         $this->options  = array(
             'whitelist' => array('src', 'lib'),
             'blacklist' => array('vendor', 'spec'),
@@ -61,7 +63,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
         }
 
         foreach ($this->reports as $format => $report) {
-            if ($this->io) {
+            if ($this->io && !($this->format === 'html' || $this->format === 'junit')) {
                 $this->io->writeln(sprintf('Generating code coverage report in %s format ...', $format));
             }
 


### PR DESCRIPTION
I created this as we use the junit output PhpSpec provides, however the output this extension produces makes the generated xml invalid.

Looks like PhpSpec will provide an `--output` parameter for writing their test results to a file directly somewhere in the future. However for now this seems like a simple fix, as I can't think of a reason for writing that line when PhpSpec is generating xml/html.
