### PR TITLE
added ext-xdebug as suggest for allow coverage generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
         "phpunit/php-code-coverage": "~2.0"
 
     },
+    "suggest": {
+        "ext-xdebug": "To allow Coverage generation."
+    },
     "require-dev": {
         "bossa/phpspec2-expect": "~1.0"
     },


### PR DESCRIPTION
if we don't have an `ext-xdebug` installed, we will got error : "No code coverage driver available"