### PR TITLE
Add support for php-code-coverage 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
     "require" : {
         "php": ">=5.3.3",
         "phpspec/phpspec": "~2.0",
-        "phpunit/php-code-coverage": "~2.0"
-
+        "phpunit/php-code-coverage": "^3"
     },
     "suggest": {
         "ext-xdebug": "To allow Coverage generation."

--- a/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
+++ b/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
@@ -142,12 +142,10 @@ class CodeCoverageListenerSpec extends ObjectBehavior
             'blacklist_files' => array('src/filtered_file')
         ));
 
-        $filter->addDirectoryToWhitelist('src')->willReturn(null);
-        $filter->removeDirectoryFromWhitelist('src/filter')->willReturn(null);
-        $filter->addDirectoryToBlacklist('src/filter')->willReturn(null);
-        $filter->addFileToWhitelist('src/filter/whilelisted_file')->willReturn(null);
-        $filter->removeFileFromWhitelist('src/filtered_file')->willReturn(null);
-        $filter->addFileToBlacklist('src/filtered_file')->willReturn(null);
+        $filter->addDirectoryToWhitelist('src')->shouldBeCalled();
+        $filter->removeDirectoryFromWhitelist('src/filter')->shouldBeCalled();
+        $filter->addFileToWhitelist('src/filter/whilelisted_file')->shouldBeCalled();
+        $filter->removeFileFromWhitelist('src/filtered_file')->shouldBeCalled();
 
         $this->beforeSuite($event);
     }

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -20,7 +20,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
         $this->reports  = $reports;
         $this->options  = array(
             'whitelist' => array('src', 'lib'),
-            'blacklist' => array('vendor', 'spec'),
+            'blacklist' => array('test', 'vendor', 'spec'),
             'whitelist_files' => array(),
             'blacklist_files' => array(),
             'output'    => array('html' => 'coverage'),
@@ -40,10 +40,8 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
 
         array_map(array($filter, 'addDirectoryToWhitelist'), $this->options['whitelist']);
         array_map(array($filter, 'removeDirectoryFromWhitelist'), $this->options['blacklist']);
-        array_map(array($filter, 'addDirectoryToBlacklist'), $this->options['blacklist']);
         array_map(array($filter, 'addFileToWhitelist'), $this->options['whitelist_files']);
         array_map(array($filter, 'removeFileFromWhitelist'), $this->options['blacklist_files']);
-        array_map(array($filter, 'addFileToBlacklist'), $this->options['blacklist_files']);
     }
 
     public function beforeExample(ExampleEvent $event)


### PR DESCRIPTION
This PR adds support for php-code-coverage 3.x

Note : the blacklist functionality has been removed from PHP_CodeCoverage_Filter in php-code-coverage 3.x, so you will probably want to create a new major version as this is a BC break.