### PR TITLE
added handling of --no-ansi symfony console argument

### DIFF
--- a/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
+++ b/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
@@ -49,7 +49,7 @@ class CodeCoverageListenerSpec extends ObjectBehavior
         $this->afterSuite($event);
     }
 
-    function it_should_output_text_report(
+    function it_should_color_output_text_report_by_default(
         \PHP_CodeCoverage $coverage,
         \PHP_CodeCoverage_Report_Text $text,
         SuiteEvent $event,
@@ -65,9 +65,35 @@ class CodeCoverageListenerSpec extends ObjectBehavior
         ));
 
         $io->isVerbose()->willReturn(false);
+        $io->isDecorated()->willReturn(true);
         $this->setIO($io);
 
         $text->process($coverage, true)->willReturn('report');
+        $io->writeln('report')->shouldBeCalled();
+
+        $this->afterSuite($event);
+    }
+
+    function it_should_not_color_output_text_report_by_default(
+        \PHP_CodeCoverage $coverage,
+        \PHP_CodeCoverage_Report_Text $text,
+        SuiteEvent $event,
+        IO $io
+    ) {
+        $reports = array(
+            'text' => $text
+        );
+
+        $this->beConstructedWith($coverage, $reports);
+        $this->setOptions(array(
+            'format' => 'text'
+        ));
+
+        $io->isVerbose()->willReturn(false);
+        $io->isDecorated()->willReturn(false);
+        $this->setIO($io);
+
+        $text->process($coverage, false)->willReturn('report');
         $io->writeln('report')->shouldBeCalled();
 
         $this->afterSuite($event);

--- a/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
+++ b/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
@@ -74,7 +74,7 @@ class CodeCoverageListenerSpec extends ObjectBehavior
         $this->afterSuite($event);
     }
 
-    function it_should_not_color_output_text_report_by_default(
+    function it_should_not_color_output_text_report_unless_specified(
         \PHP_CodeCoverage $coverage,
         \PHP_CodeCoverage_Report_Text $text,
         SuiteEvent $event,

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -89,7 +89,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
             }
 
             if ($report instanceof \PHP_CodeCoverage_Report_Text) {
-                $output = $report->process($this->coverage, /* showColors */ true);
+                $output = $report->process($this->coverage, /* showColors */ $this->io->isDecorated());
                 $this->io->writeln($output);
             } else {
                 $report->process($this->coverage, $this->options['output'][$format]);


### PR DESCRIPTION
Hi, 

I needed the ability to turn color output off in ```\PHP_CodeCoverage_Report_Text```.

Since PhpSpec uses the Symfony Console Component, and that already supports that behaviour, I simply added a check to the relevant method in ```CodeCoverageListener```

Basically behaviour is now:

```
# no color output
phpspec run --no-ansi --config=phpspec-coverage.yml

# color output
phpspec run --config=phpspec-coverage.yml
```

Also added a relevant spec to the test suite :)