### PR TITLE
Reviewed requied PHP Versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
     },
 
     "require" : {
-        "php": "^5.6|^7.0|^5.5",
+        "php": "^5.3.3|^5.4|^5.5|^5.6|^7.0",
         "phpspec/phpspec": "^2.0",
-        "phpunit/php-code-coverage": "^3|2.2.4"
+        "phpunit/php-code-coverage": "^2.2.4|^3"
     },
 
     "suggest": {


### PR DESCRIPTION
I have reviewed all dependencies versions that I have installed after add this `vendor` on my project. I can assure you I have the provided versions for your package: that project is a new one, and had no other packages installed when I added this one.

Looks like all requirements are `PHP 5.3.3` so IMHO , except if you have added some piece of code that requires a newer version, you can consider to update this requirement, and provide this package to all developers/environments that are working with a lower PHP version.

Here you can see my environment packages/versions and the link to Packagist website for each dependency, just in case you want to check it first:

[phpspec/phpspec #2.4.1](https://packagist.org/packages/phpspec/phpspec#2.4.1)
```
$ composer show -i | grep "phpspec/phpspec"
phpspec/phpspec                      2.4.1
```

[phpunit/php-code-coverage #2.2.4](https://packagist.org/packages/phpunit/php-code-coverage#2.2.4)
```
$ composer show -i | grep "phpunit/php-code-coverage"
phpunit/php-code-coverage            2.2.4
```

[bossa/phpspec2-expect #1.0.3](https://packagist.org/packages/bossa/phpspec2-expect#1.0.3)
```
$ composer show -i | grep "bossa/phpspec2-expect"
bossa/phpspec2-expect                1.0.3
```

Cheers,