### PR TITLE
Use phpdbg for code coverage when xdebug not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ code_coverage:
 * `show_uncovered_files` for including uncovered files in coverage reports (default `true`)
 * `lower_upper_bound` for coverage (default `35`)
 * `high_lower_bound` for coverage (default `70`)
+
+Running with phpdbg
+-------------------
+
+For faster execution, run phpspec with [phpdbg](http://phpdbg.com) instead of xdebug:
+```sh
+phpdbg -qrr phpspec run
+```

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
 
     "suggest": {
-        "ext-xdebug": "To allow Coverage generation."
+        "ext-xdebug": "To allow coverage generation when not using a recent version of phpdbg"
     },
 
     "require-dev": {

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -27,7 +27,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
             'format'    => array('html'),
         );
 
-        $this->enabled = extension_loaded('xdebug');
+        $this->enabled = extension_loaded('xdebug') || (PHP_SAPI === 'phpdbg');
     }
 
     public function beforeSuite(SuiteEvent $event)
@@ -73,7 +73,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
     {
         if (!$this->enabled) {
             if ($this->io && $this->io->isVerbose()) {
-                $this->io->writeln('The Xdebug extension is not loaded. No code coverage will be generated.');
+                $this->io->writeln('Did not detect Xdebug extension or phpdbg. No code coverage will be generated.');
             }
 
             return;


### PR DESCRIPTION
php-code-coverage extension already supports phpdbg generated coverage. No need to require xdebug if running via phpdbg. See #35 