### PR TITLE
Support phpunit/php-code-coverage version 4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require" : {
         "php": "^5.3.3|^5.4|^5.5|^5.6|^7.0",
         "phpspec/phpspec": "^2.0",
-        "phpunit/php-code-coverage": "^2.2.4|^3"
+        "phpunit/php-code-coverage": "^4"
     },
 
     "suggest": {

--- a/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
+++ b/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
@@ -8,9 +8,13 @@ use Prophecy\Argument;
 use PhpSpec\Console\IO;
 use PhpSpec\Event\SuiteEvent;
 
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Filter;
+use SebastianBergmann\CodeCoverage\Report;
+
 class CodeCoverageListenerSpec extends ObjectBehavior
 {
-    function let(\PHP_CodeCoverage $coverage)
+    function let(CodeCoverage $coverage)
     {
         $this->beConstructedWith($coverage, array());
     }
@@ -21,9 +25,9 @@ class CodeCoverageListenerSpec extends ObjectBehavior
     }
 
     function it_should_run_all_reports(
-        \PHP_CodeCoverage $coverage,
-        \PHP_CodeCoverage_Report_Clover $clover,
-        \PHP_CodeCoverage_Report_PHP $php,
+        CodeCoverage $coverage,
+        Report\Clover $clover,
+        Report\PHP $php,
         SuiteEvent $event,
         IO $io
     ) {
@@ -50,8 +54,8 @@ class CodeCoverageListenerSpec extends ObjectBehavior
     }
 
     function it_should_color_output_text_report_by_default(
-        \PHP_CodeCoverage $coverage,
-        \PHP_CodeCoverage_Report_Text $text,
+        CodeCoverage $coverage,
+        Report\Text $text,
         SuiteEvent $event,
         IO $io
     ) {
@@ -75,8 +79,8 @@ class CodeCoverageListenerSpec extends ObjectBehavior
     }
 
     function it_should_not_color_output_text_report_unless_specified(
-        \PHP_CodeCoverage $coverage,
-        \PHP_CodeCoverage_Report_Text $text,
+        CodeCoverage $coverage,
+        Report\Text $text,
         SuiteEvent $event,
         IO $io
     ) {
@@ -100,8 +104,8 @@ class CodeCoverageListenerSpec extends ObjectBehavior
     }
 
     function it_should_output_html_report(
-        \PHP_CodeCoverage $coverage,
-        \PHP_CodeCoverage_Report_HTML $html,
+        CodeCoverage $coverage,
+        Report\HTML $html,
         SuiteEvent $event,
         IO $io
     ) {
@@ -127,8 +131,8 @@ class CodeCoverageListenerSpec extends ObjectBehavior
     }
 
     function it_should_provide_extra_output_in_verbose_mode(
-        \PHP_CodeCoverage $coverage,
-        \PHP_CodeCoverage_Report_HTML $html,
+        CodeCoverage $coverage,
+        Report\HTML $html,
         SuiteEvent $event,
         IO $io
     ) {
@@ -152,9 +156,9 @@ class CodeCoverageListenerSpec extends ObjectBehavior
     }
 
     function it_should_correctly_handle_black_listed_files_and_directories(
-        \PHP_CodeCoverage $coverage,
+        CodeCoverage $coverage,
         SuiteEvent $event,
-        \PHP_CodeCoverage_Filter $filter
+        Filter $filter
     )
     {
         $this->beConstructedWith($coverage, array());

--- a/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
+++ b/spec/PhpSpec/Extension/Listener/CodeCoverageListenerSpec.php
@@ -105,7 +105,7 @@ class CodeCoverageListenerSpec extends ObjectBehavior
 
     function it_should_output_html_report(
         CodeCoverage $coverage,
-        Report\HTML $html,
+        Report\Html\Facade $html,
         SuiteEvent $event,
         IO $io
     ) {
@@ -132,7 +132,7 @@ class CodeCoverageListenerSpec extends ObjectBehavior
 
     function it_should_provide_extra_output_in_verbose_mode(
         CodeCoverage $coverage,
-        Report\HTML $html,
+        Report\Html\Facade $html,
         SuiteEvent $event,
         IO $io
     ) {

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -5,6 +5,10 @@ namespace PhpSpec\Extension;
 use PhpSpec\ServiceContainer;
 use PhpSpec\Extension\Listener\CodeCoverageListener;
 
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Filter;
+use SebastianBergmann\CodeCoverage\Report;
+
 /**
  * Injects a Event Subscriber into the EventDispatcher. The Subscriber
  * will before each example add CodeCoverage Information.
@@ -17,11 +21,11 @@ class CodeCoverageExtension implements \PhpSpec\Extension\ExtensionInterface
     public function load(ServiceContainer $container)
     {
         $container->setShared('code_coverage.filter', function () {
-            return new \PHP_CodeCoverage_Filter();
+            return new Filter();
         });
 
         $container->setShared('code_coverage', function ($container) {
-            return new \PHP_CodeCoverage(null, $container->get('code_coverage.filter'));
+            return new CodeCoverage(null, $container->get('code_coverage.filter'));
         });
 
         $container->setShared('code_coverage.options', function ($container) {
@@ -60,13 +64,13 @@ class CodeCoverageExtension implements \PhpSpec\Extension\ExtensionInterface
             foreach ($options['format'] as $format) {
                 switch ($format) {
                     case 'clover':
-                        $reports['clover'] = new \PHP_CodeCoverage_Report_Clover();
+                        $reports['clover'] = new Report\Clover();
                         break;
                     case 'php':
-                        $reports['php'] =  new \PHP_CodeCoverage_Report_PHP();
+                        $reports['php'] =  new Report\PHP();
                         break;
                     case 'text':
-                        $reports['text'] =  new \PHP_CodeCoverage_Report_Text(
+                        $reports['text'] =  new Report\Text(
                             $options['lower_upper_bound'],
                             $options['high_lower_bound'],
                             $options['show_uncovered_files'],
@@ -74,13 +78,13 @@ class CodeCoverageExtension implements \PhpSpec\Extension\ExtensionInterface
                         );
                         break;
                     case 'xml':
-                        $reports['xml'] =  new \PHP_CodeCoverage_Report_XML();
+                        $reports['xml'] =  new Report\XML();
                         break;
                     case 'crap4j':
-                        $reports['crap4j'] = new \PHP_CodeCoverage_Report_Crap4j();
+                        $reports['crap4j'] = new Report\Crap4j();
                         break;
                     case 'html':
-                        $reports['html'] = new \PHP_CodeCoverage_Report_HTML();
+                        $reports['html'] = new Report\HTML();
                         break;
                 }
             }

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -78,13 +78,13 @@ class CodeCoverageExtension implements \PhpSpec\Extension\ExtensionInterface
                         );
                         break;
                     case 'xml':
-                        $reports['xml'] =  new Report\XML();
+                        $reports['xml'] =  new Report\Xml\Facade();
                         break;
                     case 'crap4j':
                         $reports['crap4j'] = new Report\Crap4j();
                         break;
                     case 'html':
-                        $reports['html'] = new Report\HTML();
+                        $reports['html'] = new Report\Html\Facade();
                         break;
                 }
             }

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -6,6 +6,9 @@ use PhpSpec\Console\IO;
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SuiteEvent;
 
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report;
+
 class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSubscriberInterface
 {
     private $coverage;
@@ -14,7 +17,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
     private $options;
     private $enabled;
 
-    public function __construct(\PHP_CodeCoverage $coverage, array $reports)
+    public function __construct(CodeCoverage $coverage, array $reports)
     {
         $this->coverage = $coverage;
         $this->reports  = $reports;
@@ -88,7 +91,7 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
                 $this->io->writeln(sprintf('Generating code coverage report in %s format ...', $format));
             }
 
-            if ($report instanceof \PHP_CodeCoverage_Report_Text) {
+            if ($report instanceof Report\Text) {
                 $output = $report->process($this->coverage, /* showColors */ $this->io->isDecorated());
                 $this->io->writeln($output);
             } else {


### PR DESCRIPTION
The `phpunit/php-code-coverage` package has been bumped to version 4 that introduces namespaces. I need to use the updated version for several reasons.

So I've quickly refactored this lib to support the new namespaces.

However, I suppose this is a big BC break, so a major version bump (3.0?) when merging this would be required.