### PR TITLE
Make PhpSpecCodeCoverageExtension work with PhpSpec 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ extensions:
     - PhpSpec\Extension\CodeCoverageExtension
 ```
 
-Now run your specs with the normal `phpspec run` and voila your code coverage will be available in
+Now run your specs with the normal `phpspec run` and voilà your code coverage will be available in
 `coverage`.
 
 Configuration Options
@@ -43,12 +43,16 @@ extensions:
 * `lower_upper_bound` for coverage (default `35`)
 * `high_lower_bound` for coverage (default `70`)
 
-**Attention**: If the clover format option requires you to also set an output location!
+**Note**: If the clover format option requires you to also set an output location!
 
-Running with phpdbg
+Running with phpdbg (PHP 7.x and up)
 -------------------
 
 For faster execution, run phpspec with [phpdbg](http://phpdbg.com) instead of xdebug:
 ```sh
 phpdbg -qrr phpspec run
 ```
+
+**Note**: The code coverage extension only works with phpdbg if you're using PHP 7.
+In PHP 5.6, phpdbg is missing the phpdbg_start_oplog function which is required to generate
+code coverage.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Configuration Options
 ---------------------
 
 It is possible to control a bit out how the code coverage is done through `phpspec.yml`. This is done by
-adding a `code_coverage` key which takes a hash of options.
+adding a hash of options to the extension key.
 
 * `whitelist` takes an array of directories to whitelist (default: `lib`, `src`).
 * `whitelist_files` takes an array of files to whitelist (default: none).
@@ -30,13 +30,14 @@ adding a `code_coverage` key which takes a hash of options.
 * `format` (optional) could be one or many of: `clover`, `php`, `text`, `html` (default `html`)
 * `output` takes a location relative to the place you are running `phpspec run` (default: `coverage`). If you configure multiple formats, takes a hash of format:output e.g.
 ```yaml
-code_coverage:
-  format:
-    - html
-    - clover
-  output:
-    html: coverage
-    clover: coverage.xml
+extensions:
+  PhpSpec\Extension\CodeCoverageExtension:
+    format:
+      - html
+      - clover
+    output:
+      html: coverage
+      clover: coverage.xml
 ```
 * `show_uncovered_files` for including uncovered files in coverage reports (default `true`)
 * `lower_upper_bound` for coverage (default `35`)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ extensions:
 * `lower_upper_bound` for coverage (default `35`)
 * `high_lower_bound` for coverage (default `70`)
 
+**Attention**: If the clover format option requires you to also set an output location!
+
 Running with phpdbg
 -------------------
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license" : "MIT",
 
     "autoload" : {
-        "psr-4" : { "PhpSpec\\Extension\\" : "src/" }
+        "psr-4" : { "HenrikBjorn\\PhpSpecCodeCoverage\\" : "src/" }
     },
 
     "require" : {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license" : "MIT",
 
     "autoload" : {
-        "psr-4" : { "HenrikBjorn\\PhpSpecCodeCoverage\\" : "src/" }
+        "psr-4" : { "PhpSpecCodeCoverage\\" : "src/" }
     },
 
     "require" : {
@@ -18,7 +18,7 @@
     },
 
     "require-dev": {
-        "bossa/phpspec2-expect": "^1.0"
+        "bossa/phpspec2-expect": "dev-master"
     },
 
     "extra" : {

--- a/spec/PhpSpecCodeCoverage/CodeCoverageExtensionSpec.php
+++ b/spec/PhpSpecCodeCoverage/CodeCoverageExtensionSpec.php
@@ -1,24 +1,23 @@
 <?php
 
-namespace spec\PhpSpec\Extension;
+namespace spec\PhpSpecCodeCoverage;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
-use PhpSpec\ServiceContainer;
+use PhpSpec\ServiceContainer\IndexedServiceContainer;
 
 class CodeCoverageExtensionSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('PhpSpec\Extension\CodeCoverageExtension');
+        $this->shouldHaveType('\PhpSpecCodeCoverage\CodeCoverageExtension');
     }
 
     function it_should_use_html_format_by_default()
     {
-        $container = new ServiceContainer;
-        $container->setParam('code_coverage', array());
-        $this->load($container);
+        $container = new IndexedServiceContainer;
+        $this->load($container, []);
 
         $options = $container->get('code_coverage.options');
         expect($options['format'])->toBe(array('html'));
@@ -26,7 +25,7 @@ class CodeCoverageExtensionSpec extends ObjectBehavior
 
     function it_should_transform_format_into_array()
     {
-        $container = new ServiceContainer;
+        $container = new IndexedServiceContainer;
         $container->setParam('code_coverage', array('format' => 'html'));
         $this->load($container);
 
@@ -36,7 +35,7 @@ class CodeCoverageExtensionSpec extends ObjectBehavior
 
     function it_should_use_singular_output()
     {
-        $container = new ServiceContainer;
+        $container = new IndexedServiceContainer;
         $container->setParam('code_coverage', array('output' => 'test', 'format' => 'foo'));
         $this->load($container);
 

--- a/spec/PhpSpecCodeCoverage/Listener/CodeCoverageListenerSpec.php
+++ b/spec/PhpSpecCodeCoverage/Listener/CodeCoverageListenerSpec.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace spec\PhpSpec\Extension\Listener;
+namespace spec\PhpSpecCodeCoverage\Listener;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
-use PhpSpec\Console\IO;
+use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\SuiteEvent;
 
 use SebastianBergmann\CodeCoverage\CodeCoverage;
@@ -14,14 +14,14 @@ use SebastianBergmann\CodeCoverage\Report;
 
 class CodeCoverageListenerSpec extends ObjectBehavior
 {
-    function let(CodeCoverage $coverage)
+    function let(ConsoleIO $io, CodeCoverage $coverage)
     {
-        $this->beConstructedWith($coverage, array());
+        $this->beConstructedWith($io, $coverage, array());
     }
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('PhpSpec\Extension\Listener\CodeCoverageListener');
+        $this->shouldHaveType('\PhpSpecCodeCoverage\Listener\CodeCoverageListener');
     }
 
     function it_should_run_all_reports(
@@ -29,14 +29,14 @@ class CodeCoverageListenerSpec extends ObjectBehavior
         Report\Clover $clover,
         Report\PHP $php,
         SuiteEvent $event,
-        IO $io
+        ConsoleIO $io
     ) {
         $reports = array(
             'clover' => $clover,
             'php' =>  $php
         );
 
-        $this->beConstructedWith($coverage, $reports);
+        $this->beConstructedWith($io, $coverage, $reports);
         $this->setOptions(array(
             'format' => array('clover', 'php'),
             'output' => array(
@@ -44,8 +44,6 @@ class CodeCoverageListenerSpec extends ObjectBehavior
                 'php' => 'coverage.php'
             )
         ));
-
-        $this->setIO($io);
 
         $clover->process($coverage, 'coverage.xml')->shouldBeCalled();
         $php->process($coverage, 'coverage.php')->shouldBeCalled();
@@ -57,20 +55,19 @@ class CodeCoverageListenerSpec extends ObjectBehavior
         CodeCoverage $coverage,
         Report\Text $text,
         SuiteEvent $event,
-        IO $io
+        ConsoleIO $io
     ) {
         $reports = array(
             'text' => $text
         );
 
-        $this->beConstructedWith($coverage, $reports);
+        $this->beConstructedWith($io, $coverage, $reports);
         $this->setOptions(array(
             'format' => 'text'
         ));
 
         $io->isVerbose()->willReturn(false);
         $io->isDecorated()->willReturn(true);
-        $this->setIO($io);
 
         $text->process($coverage, true)->willReturn('report');
         $io->writeln('report')->shouldBeCalled();
@@ -82,20 +79,19 @@ class CodeCoverageListenerSpec extends ObjectBehavior
         CodeCoverage $coverage,
         Report\Text $text,
         SuiteEvent $event,
-        IO $io
+        ConsoleIO $io
     ) {
         $reports = array(
             'text' => $text
         );
 
-        $this->beConstructedWith($coverage, $reports);
+        $this->beConstructedWith($io, $coverage, $reports);
         $this->setOptions(array(
             'format' => 'text'
         ));
 
         $io->isVerbose()->willReturn(false);
         $io->isDecorated()->willReturn(false);
-        $this->setIO($io);
 
         $text->process($coverage, false)->willReturn('report');
         $io->writeln('report')->shouldBeCalled();
@@ -107,21 +103,19 @@ class CodeCoverageListenerSpec extends ObjectBehavior
         CodeCoverage $coverage,
         Report\Html\Facade $html,
         SuiteEvent $event,
-        IO $io
+        ConsoleIO $io
     ) {
         $reports = array(
             'html' => $html
         );
 
-        $this->beConstructedWith($coverage, $reports);
+        $this->beConstructedWith($io, $coverage, $reports);
         $this->setOptions(array(
             'format' => 'html',
             'output' => array('html' => 'coverage'),
         ));
 
         $io->isVerbose()->willReturn(false);
-        $this->setIO($io);
-
         $io->writeln(Argument::any())->shouldNotBeCalled();
 
 
@@ -134,21 +128,19 @@ class CodeCoverageListenerSpec extends ObjectBehavior
         CodeCoverage $coverage,
         Report\Html\Facade $html,
         SuiteEvent $event,
-        IO $io
+        ConsoleIO $io
     ) {
         $reports = array(
             'html' => $html,
         );
 
-        $this->beConstructedWith($coverage, $reports);
+        $this->beConstructedWith($io, $coverage, $reports);
         $this->setOptions(array(
             'format' => 'html',
             'output' => array('html' => 'coverage'),
         ));
 
         $io->isVerbose()->willReturn(true);
-        $this->setIO($io);
-
         $io->writeln('')->shouldBeCalled();
         $io->writeln('Generating code coverage report in html format ...')->shouldBeCalled();
 
@@ -158,10 +150,11 @@ class CodeCoverageListenerSpec extends ObjectBehavior
     function it_should_correctly_handle_black_listed_files_and_directories(
         CodeCoverage $coverage,
         SuiteEvent $event,
-        Filter $filter
+        Filter $filter,
+        ConsoleIO $io
     )
     {
-        $this->beConstructedWith($coverage, array());
+        $this->beConstructedWith($io, $coverage, array());
 
         $coverage->filter()->willReturn($filter);
 

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -103,6 +103,6 @@ class CodeCoverageExtension implements \PhpSpec\Extension
             $listener->setOptions($container->getParam('code_coverage', array()));
 
             return $listener;
-        });
+        }, ['event_dispatcher.listeners']);
     }
 }

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -1,35 +1,36 @@
 <?php
 
-namespace PhpSpec\Extension;
+namespace HenrikBjorn\PhpSpecCodeCoverage;
 
 use PhpSpec\ServiceContainer;
-use PhpSpec\Extension\Listener\CodeCoverageListener;
 
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\CodeCoverage\Report;
 
+use HenrikBjorn\PhpSpecCodeCoverage\Listener\CodeCoverageListener;
+
 /**
- * Injects a Event Subscriber into the EventDispatcher. The Subscriber
- * will before each example add CodeCoverage Information.
+ * Injects an Event Subscriber into the EventDispatcher.
+ * The Subscriber will, before each example, add CodeCoverage information.
  */
-class CodeCoverageExtension implements \PhpSpec\Extension\ExtensionInterface
+class CodeCoverageExtension implements \PhpSpec\Extension
 {
     /**
      * {@inheritDoc}
      */
-    public function load(ServiceContainer $container)
+    public function load(ServiceContainer $container, array $params = [])
     {
-        $container->setShared('code_coverage.filter', function () {
+        $container->define('code_coverage.filter', function () {
             return new Filter();
         });
 
-        $container->setShared('code_coverage', function ($container) {
+        $container->define('code_coverage', function ($container) {
             return new CodeCoverage(null, $container->get('code_coverage.filter'));
         });
 
-        $container->setShared('code_coverage.options', function ($container) {
-            $options = $container->getParam('code_coverage');
+        $container->define('code_coverage.options', function ($container) use ($params) {
+            $options = !empty($params) ? $params : $container->getParam('code_coverage');
 
             if (!isset($options['format'])) {
                 $options['format'] = array('html');
@@ -57,7 +58,7 @@ class CodeCoverageExtension implements \PhpSpec\Extension\ExtensionInterface
             return $options;
         });
 
-        $container->setShared('code_coverage.reports', function ($container) {
+        $container->define('code_coverage.reports', function ($container) {
             $options = $container->get('code_coverage.options');
 
             $reports = array();
@@ -93,7 +94,7 @@ class CodeCoverageExtension implements \PhpSpec\Extension\ExtensionInterface
             return $reports;
         });
 
-        $container->setShared('event_dispatcher.listeners.code_coverage', function ($container) {
+        $container->define('event_dispatcher.listeners.code_coverage', function ($container) {
             $listener = new CodeCoverageListener(
                 $container->get('code_coverage'),
                 $container->get('code_coverage.reports')

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -96,10 +96,10 @@ class CodeCoverageExtension implements \PhpSpec\Extension
 
         $container->define('event_dispatcher.listeners.code_coverage', function ($container) {
             $listener = new CodeCoverageListener(
+		$container->get('console.io'),
                 $container->get('code_coverage'),
                 $container->get('code_coverage.reports')
             );
-            $listener->setIO($container->get('console.io'));
             $listener->setOptions($container->getParam('code_coverage', array()));
 
             return $listener;

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace HenrikBjorn\PhpSpecCodeCoverage;
+namespace PhpSpecCodeCoverage;
 
 use PhpSpec\ServiceContainer;
 
@@ -8,7 +8,7 @@ use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\CodeCoverage\Report;
 
-use HenrikBjorn\PhpSpecCodeCoverage\Listener\CodeCoverageListener;
+use PhpSpecCodeCoverage\Listener\CodeCoverageListener;
 
 /**
  * Injects an Event Subscriber into the EventDispatcher.
@@ -96,7 +96,7 @@ class CodeCoverageExtension implements \PhpSpec\Extension
 
         $container->define('event_dispatcher.listeners.code_coverage', function ($container) {
             $listener = new CodeCoverageListener(
-		$container->get('console.io'),
+                $container->get('console.io'),
                 $container->get('code_coverage'),
                 $container->get('code_coverage.reports')
             );

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace HenrikBjorn\PhpSpecCodeCoverage\Listener;
+namespace PhpSpecCodeCoverage\Listener;
 
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\ExampleEvent;
@@ -21,7 +21,7 @@ class CodeCoverageListener implements EventSubscriberInterface
 
     public function __construct(ConsoleIO $io, CodeCoverage $coverage, array $reports)
     {
-	$this->io = $io;
+        $this->io = $io;
         $this->coverage = $coverage;
         $this->reports  = $reports;
         $this->options  = array(
@@ -56,12 +56,10 @@ class CodeCoverageListener implements EventSubscriberInterface
             [$filter, 'removeDirectoryFromWhitelist'],
             $this->options['blacklist']
         );
-
         array_map(
             [$filter, 'addFileToWhitelist'],
             $this->options['whitelist_files']
         );
-
         array_map(
             [$filter, 'removeFileFromWhitelist'],
             $this->options['blacklist_files']

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -9,7 +9,9 @@ use PhpSpec\Event\SuiteEvent;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report;
 
-class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSubscriberInterface
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CodeCoverageListener implements EventSubscriberInterface
 {
     private $coverage;
     private $reports;
@@ -41,10 +43,24 @@ class CodeCoverageListener implements \Symfony\Component\EventDispatcher\EventSu
 
         $filter = $this->coverage->filter();
 
-        array_map(array($filter, 'addDirectoryToWhitelist'), $this->options['whitelist']);
-        array_map(array($filter, 'removeDirectoryFromWhitelist'), $this->options['blacklist']);
-        array_map(array($filter, 'addFileToWhitelist'), $this->options['whitelist_files']);
-        array_map(array($filter, 'removeFileFromWhitelist'), $this->options['blacklist_files']);
+        array_walk(
+            $this->options['whitelist'],
+            [$filter, 'addDirectoryToWhitelist']
+        );
+        array_walk(
+            $this->options['blacklist']
+            [$filter, 'removeDirectoryFromWhitelist']
+        );
+
+        array_walk(
+            $this->options['whitelist_files'],
+            [$filter, 'addFileToWhitelist']
+        );
+
+        array_walk(
+            $this->options['blacklist_files'],
+            [$filter, 'removeFileFromWhitelist']
+        );
     }
 
     public function beforeExample(ExampleEvent $event)

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -36,6 +36,10 @@ class CodeCoverageListener implements EventSubscriberInterface
         $this->enabled = extension_loaded('xdebug') || (PHP_SAPI === 'phpdbg');
     }
 
+    /**
+     * Note: We use array_map() instead of array_walk() because the latter expects
+     * the callback to take the value as the first and the index as the seconds parameter.
+     */
     public function beforeSuite(SuiteEvent $event)
     {
         if (!$this->enabled) {
@@ -44,23 +48,23 @@ class CodeCoverageListener implements EventSubscriberInterface
 
         $filter = $this->coverage->filter();
 
-        array_walk(
-            $this->options['whitelist'],
-            [$filter, 'addDirectoryToWhitelist']
+        array_map(
+            [$filter, 'addDirectoryToWhitelist'],
+            $this->options['whitelist']
         );
-        array_walk(
-            $this->options['blacklist'],
-            [$filter, 'removeDirectoryFromWhitelist']
-        );
-
-        array_walk(
-            $this->options['whitelist_files'],
-            [$filter, 'addFileToWhitelist']
+        array_map(
+            [$filter, 'removeDirectoryFromWhitelist'],
+            $this->options['blacklist']
         );
 
-        array_walk(
-            $this->options['blacklist_files'],
-            [$filter, 'removeFileFromWhitelist']
+        array_map(
+            [$filter, 'addFileToWhitelist'],
+            $this->options['whitelist_files']
+        );
+
+        array_map(
+            [$filter, 'removeFileFromWhitelist'],
+            $this->options['blacklist_files']
         );
     }
 

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -2,7 +2,7 @@
 
 namespace HenrikBjorn\PhpSpecCodeCoverage\Listener;
 
-use PhpSpec\Console\ConsoleIO as IO;
+use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SuiteEvent;
 
@@ -19,8 +19,9 @@ class CodeCoverageListener implements EventSubscriberInterface
     private $options;
     private $enabled;
 
-    public function __construct(CodeCoverage $coverage, array $reports)
+    public function __construct(ConsoleIO $io, CodeCoverage $coverage, array $reports)
     {
+	$this->io = $io;
         $this->coverage = $coverage;
         $this->reports  = $reports;
         $this->options  = array(
@@ -48,7 +49,7 @@ class CodeCoverageListener implements EventSubscriberInterface
             [$filter, 'addDirectoryToWhitelist']
         );
         array_walk(
-            $this->options['blacklist']
+            $this->options['blacklist'],
             [$filter, 'removeDirectoryFromWhitelist']
         );
 
@@ -114,11 +115,6 @@ class CodeCoverageListener implements EventSubscriberInterface
                 $report->process($this->coverage, $this->options['output'][$format]);
             }
         }
-    }
-
-    public function setIO(IO $io)
-    {
-        $this->io = $io;
     }
 
     public function setOptions(array $options)

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace PhpSpec\Extension\Listener;
+namespace HenrikBjorn\PhpSpecCodeCoverage\Listener;
 
-use PhpSpec\Console\IO;
+use PhpSpec\Console\ConsoleIO as IO;
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SuiteEvent;
 


### PR DESCRIPTION
Adapted the extension to work with PhpSpec 3.x and changed a few other things like namespace, and passing the ConsoleIO directly during Listener initialisation.