### PR TITLE
Added support for "phpunit/php-code-coverage" 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: php
 
-php:
-    - 5.6
-    - 7.0
-
 sudo: false
+
+matrix:
+    include:
+        - php: 5.6
+        - php: 5.6
+          env: deps=low
+        - php: 7.0
+        - php: 7.1
 
 cache:
     directories:
@@ -12,5 +16,8 @@ cache:
 
 install:
     - travis_retry composer install
+
+before_script:
+    - if [[ $deps = low ]]; then composer update --prefer-lowest --prefer-stable; fi
 
 script: ./vendor/bin/phpspec run

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require" : {
         "php": "^5.5|^5.6|^7.0",
         "phpspec/phpspec": "^3.0",
-        "phpunit/php-code-coverage": "^4.0"
+        "phpunit/php-code-coverage": "^4.0|^5.0"
     },
 
     "suggest": {


### PR DESCRIPTION
**PHPUnit** >= 6.0 requires _phpunit/php-code-coverage_ version 5 or greater. Those who also want to use PHPUnit 6 won't be able to upgrade unless this project supports the version 5.0 of the code-coverage library.

Travis-CI tests will test both supported versions of _phpunit/php-code-coverage_, 4.0 and 5.0.

Also, added PHP 7.1 to the test suite.